### PR TITLE
feature(endpoint):create the delete article endpoint

### DIFF
--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -102,6 +102,39 @@ class ArticleController {
     });
   }
 
+
+  
+  static async deleteArticle(req, res) {
+    const { articleId } = req.params;
+    let authorId = req.body.authorId;
+
+    if (authorId === undefined) {
+          return res.status(400).json({
+            status: 'error',  
+            error: 'authorId not supplied',
+        });
+    }
+      authorId = parseInt(authorId, 10);
+
+    if (isNaN(articleId)) return res.status(400).json({ status: 'error', error: 'ArticleId must be a number'});
+    if (isNaN(authorId)) return res.status(400).json({ status: 'error', error: 'AuthorId must be a number'});
+
+    const articleExist = await ArticleModel.findByJoinEmployees(`articles.authorid=employees.userid`, `articleid=${articleId} AND authorid=${authorId}`);
+    if (articleExist) {
+      if (articleExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with article' });
+      if (articleExist.length < 1) return res.status(400).json({ status: 'error', error: 'Article not found' });
+    }
+    console.log('article exist', articleExist[0]);
+    const articleDeleted = await ArticleModel.delete(`articleid=${articleId}`);
+
+    return res.status(200).json({
+      status: 'success',
+      data: {
+        message: 'Article successfully deleted'
+      }
+    });
+  }
+
 } 
 
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,5 +1,5 @@
 import db from '../db';
-import { findQuery, updateQuery } from '../db/query';
+import { findQuery, updateQuery, deleteQuery } from '../db/query';
 import 'regenerator-runtime';
 
 export default class BaseModel {
@@ -47,23 +47,23 @@ export default class BaseModel {
   }
 
  
-  // static async delete(position) {
-  //   let obj = this.name;
-  //   obj = obj.replace('Model', 's').toLowerCase();
-  //   // console.log(obj);
-  //   // try {
-  //   const res = await db.query(...deleteQuery(obj, position))
-  //     .then(result => result.rows)
-  //     .catch(err => {
-  //       return 'Error found here!', err.message;
-  //     });
-  //   // console.log(res);
-  //   // return res;
-  //   // } catch(err) {
-  //   // console.log('Error with try catch');
-  //   // }
-  //   return res;
-  // }
+  static async delete(position) {
+    let obj = this.name;
+    obj = obj.replace('Model', 's').toLowerCase();
+    // console.log(obj);
+    // try {
+    const res = await db.query(...deleteQuery(obj, position))
+      .then(result => result.rows)
+      .catch(err => {
+        return 'Error found here!', err.message;
+      });
+    // console.log(res);
+    // return res;
+    // } catch(err) {
+    // console.log('Error with try catch');
+    // }
+    return res;
+  }
 
   static async update(position, condition, by) {
     let obj = this.name;

--- a/src/routes/articleRoutes.js
+++ b/src/routes/articleRoutes.js
@@ -7,6 +7,8 @@ const router = express.Router();
 router.post('/', ArticleController.createArticle);
 
 router.patch('/:articleId', ArticleController.updateArticle);
+
+router.delete('/:articleId', ArticleController.deleteArticle);
  
 
 export default router;

--- a/src/test/test.spec.js
+++ b/src/test/test.spec.js
@@ -322,7 +322,7 @@ describe('Article Endpoints', () => {
 
   it('updateArticle method (PATCH) should update article with title & article', (done) => {
     chai.request(server)
-      .post('/api/v1/articles/1')
+      .patch('/api/v1/articles/1')
       .send({
         authorId: 1,
         title: `Test Update Edition${count}`,
@@ -346,7 +346,7 @@ describe('Article Endpoints', () => {
 
   it('updateArticle method (PATCH) should return ERROR if articleId is not a number', (done) => {
     chai.request(server)
-      .post('/api/v1/articles/a')
+      .patch('/api/v1/articles/a')
       .send({
         authorId: 1,
         title: `Test Update Edition${count}`,
@@ -366,9 +366,9 @@ describe('Article Endpoints', () => {
 
   it('updateArticle method (PATCH) should return ERROR if authorId is not a number', (done) => {
     chai.request(server)
-      .post('/api/v1/articles/1')
+      .patch('/api/v1/articles/1')
       .send({
-        authorId: a,
+        authorId: 'a',
         title: `Test Update Edition${count}`,
         article: 'This is one of the test edition articles, published by @animalworldng',
       })
@@ -386,7 +386,7 @@ describe('Article Endpoints', () => {
 
   it('updateArticle method (PATCH) should return ERROR if any value is missing', (done) => {
     chai.request(server)
-      .post('/api/v1/articles/1')
+      .patch('/api/v1/articles/1')
       .send({
         authorId: 1,
         title: '',
@@ -406,11 +406,107 @@ describe('Article Endpoints', () => {
   
   it('updateArticle method (POST) should return ERROR if article is NOT FOUND', (done) => {
     chai.request(server)
-      .post('/api/v1/articles/100000')
+      .patch('/api/v1/articles/100000')
       .send({
         authorId: 1,
         title: `Test Edition`,
         article: 'This is one of the test edition articles, published by @animalworldng',
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
+    // Test deleteArticle Endpoints
+  it('deleteArticle method (DELETE) should exist', () => {
+    ArticleController.deleteArticle.should.exist;
+  });
+
+  it('deleteArticle method (DELETE) should delete an article', (done) => {
+    chai.request(server)
+      .delete('/api/v1/articles/1')
+      .send({
+        authorId: 1,
+      })
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('data');
+        res.body.data.should.be.a('object');
+        res.body.data.should.have.property('message');
+      });
+    done();
+  });
+
+  it('deleteArticle method (DELETE) should return ERROR if articleId is not a number', (done) => {
+    chai.request(server)
+      .delete('/api/v1/articles/a')
+      .send({
+        authorId: 1,
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
+  it('deleteArticle method (PATCH) should return ERROR if authorId is not a number', (done) => {
+    chai.request(server)
+      .delete('/api/v1/articles/1')
+      .send({
+        authorId: 'a',
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
+  it('deleteArticle method (PATCH) should return ERROR if any value is missing', (done) => {
+    chai.request(server)
+      .delete('/api/v1/articles/1')
+      .send({
+        authorId: '',
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+  
+  it('deleteArticle method (POST) should return ERROR if article is NOT FOUND', (done) => {
+    chai.request(server)
+      .delete('/api/v1/articles/100000')
+      .send({
+        authorId: 1,
       })
       .end((err, res) => {
         res.should.have.status(400);


### PR DESCRIPTION
What does this PR do?
create an endpoint for employees to delete their articles

Description of Task to be completed?
create endpoint where registered users can delete their articles by sending article details by a DELETE request to '/api/v1/articles/:articleId'

How should this be manually tested?
Clone repo, run npm install, test with Postman

Any background context you want to provide? NA
What are the relevant pivotal tracker stories?
Github Project Board : card-#29067711

Screenshots (if appropriate):
https://snipboard.io/1homyw.jpg

Questions: NA