### PR TITLE
#29067759:create the delete gif post endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ services :
   - postgresql
 
 before_script:
-  - psql -c 'create database test_teamwork;' -U postgres
-  - psql -c `create user postgres with password 'animalworld';` -U postgres
+  # - psql -c 'create database test_teamwork;' -U postgres
+  # - psql -c `create user postgres with password 'animalworld';` -U postgres
   # - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   # - chmod +x ./cc-test-reporter
   # - ./cc-test-reporter before-build

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ An internal social network for employees of an organization
 
 [![Build Status](https://travis-ci.com/thevetdoctor/teamwork.svg?token=1W6dsC3j7dgMFzDtHnEz&branch=develop)](https://travis-ci.com/thevetdoctor/teamwork)
 [![Coverage Status](https://coveralls.io/repos/github/thevetdoctor/teamwork/badge.svg?branch=develop)](https://coveralls.io/github/thevetdoctor/teamwork?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/thevetdoctor/teamwork/badge.svg?branch=ft-post-articles-endpoint-card-29067636)](https://coveralls.io/github/thevetdoctor/teamwork?branch=ft-post-articles-endpoint-card-29067636)

--- a/build/controllers/gifController.js
+++ b/build/controllers/gifController.js
@@ -1,0 +1,218 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _gifModel = _interopRequireDefault(require("../models/gifModel"));
+
+var _employeeModel = _interopRequireDefault(require("../models/employeeModel"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+var GifController =
+/*#__PURE__*/
+function () {
+  function GifController() {
+    _classCallCheck(this, GifController);
+  }
+
+  _createClass(GifController, null, [{
+    key: "deleteGif",
+    // create GIFs
+    // static async createGif(req, res) {
+    //     const { title, imageUrl } = req.body;
+    //     // const authorId = parseInt(req.body.authorId, 10);
+    //     let authorId = req.body.authorId;
+    //     const newGif = new GifModel(authorId, title, imageUrl);
+    //     // console.log(newGif);
+    // const missingValue = Object.keys(newGif)
+    //                            .filter(item => ((newGif[item] === undefined) || (newGif[item] === '')));
+    // // console.log(missingValue);
+    // if (missingValue.length > 0) {
+    //       return res.status(400).json({
+    //         status: 'error',  
+    //         error: `${missingValue} not supplied`,
+    //     });
+    // }
+    //     const authorExist = await EmployeeModel.find(`userid=${newGif.authorId}`);
+    //     if (authorExist) {
+    //       if (authorExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with author' });
+    //       if (authorExist.length < 1) return res.status(400).json({ status: 'error', error: 'Author not found' });
+    //     }
+    //     const gifExist = await GifModel.find(`title=${newGif.title}`);
+    //     // console.log('gif exist', gifExist);
+    //     if (gifExist) {
+    //       if (gifExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with GIF' });
+    //       if (gifExist.length > 0) return res.status(400).json({ status: 'error', error: 'GIF already exists' });
+    //     }
+    //     const createdGif = await newGif.save();
+    //     if (createdGif.indexOf('not') >= 0) {
+    //       return res.status(400).json({ status: 'error', error: 'Some error found with new GIF' });
+    //     }
+    //     const data = {
+    //         gifId: createdGif[0].gifId,
+    //         message: 'GIF image successfully posted',
+    //         createdOn: createdGif[0].createdon,
+    //         title: createdGif[0].title,
+    //         imageUrl: createdGif[0].imageurl,
+    //     }
+    //     return res.status(201).json({
+    //         status: 'success',
+    //         data,
+    //      });
+    //   }
+    // Delete GIFs by ID
+    value: function deleteGif(req, res) {
+      var gifId, authorId, gifExist, gifDeleted;
+      return regeneratorRuntime.async(function deleteGif$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              gifId = req.params.gifId;
+              authorId = req.body.authorId;
+
+              if (!(authorId === undefined)) {
+                _context.next = 4;
+                break;
+              }
+
+              return _context.abrupt("return", res.status(400).json({
+                status: 'error',
+                error: 'authorId not supplied'
+              }));
+
+            case 4:
+              authorId = parseInt(authorId, 10);
+
+              if (!isNaN(gifId)) {
+                _context.next = 7;
+                break;
+              }
+
+              return _context.abrupt("return", res.status(400).json({
+                status: 'error',
+                error: 'gifId must be a number'
+              }));
+
+            case 7:
+              if (!isNaN(authorId)) {
+                _context.next = 9;
+                break;
+              }
+
+              return _context.abrupt("return", res.status(400).json({
+                status: 'error',
+                error: 'authorId must be a number'
+              }));
+
+            case 9:
+              _context.next = 11;
+              return regeneratorRuntime.awrap(_gifModel["default"].findByJoin('employees', "gifs.authorid=employees.userid", "gifid=".concat(gifId, " AND authorid=").concat(authorId)));
+
+            case 11:
+              gifExist = _context.sent;
+
+              if (!gifExist) {
+                _context.next = 17;
+                break;
+              }
+
+              if (!(gifExist.indexOf('not') >= 0)) {
+                _context.next = 15;
+                break;
+              }
+
+              return _context.abrupt("return", res.status(400).json({
+                status: 'error',
+                error: 'Some error found with GIF'
+              }));
+
+            case 15:
+              if (!(gifExist.length < 1)) {
+                _context.next = 17;
+                break;
+              }
+
+              return _context.abrupt("return", res.status(400).json({
+                status: 'error',
+                error: 'GIF not found'
+              }));
+
+            case 17:
+              _context.next = 19;
+              return regeneratorRuntime.awrap(_gifModel["default"]["delete"]("gifid=".concat(gifId)));
+
+            case 19:
+              gifDeleted = _context.sent;
+              return _context.abrupt("return", res.status(200).json({
+                status: 'success',
+                data: {
+                  message: 'gif post successfully deleted'
+                }
+              }));
+
+            case 21:
+            case "end":
+              return _context.stop();
+          }
+        }
+      });
+    } // Create comment on gif posts by ID
+    // static async createComment(req, res) {
+    //     const { authorId, comment } = req.body;
+    //     const { articleId } = req.params;
+    //         const commentToBeCreated = new CommentModel(authorId, gifId, comment);
+    //         // console.log(commentToBeCreated);
+    //         const missingValue = Object.keys(commentToBeCreated)
+    //                                   .filter(item => ((commentToBeCreated[item] === undefined) || (commentToBeCreated[item] === '')));
+    //         // console.log(missingValue);
+    //         if (missingValue.length > 0) {
+    //               return res.status(400).json({
+    //                 status: 'error',  
+    //                 error: `${missingValue} not supplied`,
+    //             });
+    //         }
+    //       if (isNaN(gifId)) return res.status(400).json({ status: 'error', error: 'gifId must be a number'});
+    //       if (isNaN(authorId)) return res.status(400).json({ status: 'error', error: 'authorId must be a number'});
+    //       const gifExist = await GifModel.findByJoin('employees', `articles.authorid=employees.userid`, `gifarticleid=${gifarticleId} AND authorid=${authorId}`);
+    //       if (gifExist) {
+    //         if (gifExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with gif post' });
+    //         if (gifExist.length < 1) return res.status(400).json({ status: 'error', error: 'gif post not found' });
+    //       }
+    //       // console.log('GIF exist', gifExist[0]);
+    //       const commentExist = await CommentModel.findByJoin('gifs', `comments.gifid=gifs.gifid`, `gifs.gifid=${gifId} AND comments.comment='${comment}'`);
+    //       // console.log('comment exist', commentExist);
+    //       if (commentExist) {
+    //         if (commentExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found' });
+    //         if (commentExist.length > 0) return res.status(400).json({ status: 'error', error: 'Same comment already given' });
+    //       }
+    //       const newComment = await commentToBeCreated.save();
+    //       if (newComment.indexOf('not') >= 0) {
+    //         return res.status(400).json({ error: 'Some error found with new comment' });
+    //       }
+    //       const data = {
+    //         message: 'Comment successfully created',
+    //         createdOn: newComment[0].createdon,
+    //         gifTitle: gifExist[0].title,
+    //         comment,
+    //       }
+    //       return res.status(201).json({
+    //         data,
+    //       });
+    //   }
+
+  }]);
+
+  return GifController;
+}();
+
+var _default = GifController;
+exports["default"] = _default;

--- a/build/controllers/index.js
+++ b/build/controllers/index.js
@@ -6,12 +6,6 @@ Object.defineProperty(exports, "__esModule", {
 exports["default"] = void 0;
 var TestController = {
   test: function test(req, res, next) {
-    // if(err) {
-    //     return res.status(400).json({
-    //         status: 'error',
-    //         error: 'test setup has some error'
-    //     });
-    // }
     res.status(200).json({
       status: 'success',
       data: {

--- a/build/db/index.js
+++ b/build/db/index.js
@@ -9,6 +9,7 @@ var _pg = require("pg");
 
 require("dotenv/config");
 
+var elephantSql = 'postgres://aikuwuqy:VwJSaP-pOdEc--_ZNpS-g2zHekiTgLJK@raja.db.elephantsql.com:5432/aikuwuqy';
 var dbUrl = {
   host: process.env.HOST,
   user: process.env.USER,
@@ -26,8 +27,9 @@ var dbUrlTest = {
 console.log('NODE_ENV', process.env.NODE_ENV);
 var db;
 
-if (process.env.NODE_ENV === 'test') {
-  db = new _pg.Client(dbUrlTest);
+if (process.env.NODE_ENV !== 'test') {
+  // db = new Client(dbUrlTest);
+  db = new _pg.Client(elephantSql);
   console.log('Environment => Testing');
 } else {
   db = new _pg.Client(dbUrl); // db = new Client(process.env.DATABASE_URL);

--- a/build/models/gifModel.js
+++ b/build/models/gifModel.js
@@ -1,0 +1,106 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _index = _interopRequireDefault(require("./index"));
+
+var _db = _interopRequireDefault(require("../db"));
+
+var _query = require("../db/query");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var GifModel =
+/*#__PURE__*/
+function (_BaseModel) {
+  _inherits(GifModel, _BaseModel);
+
+  function GifModel(authorId, title, imageUrl) {
+    var _this;
+
+    _classCallCheck(this, GifModel);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(GifModel).call(this));
+    _this.authorId = authorId;
+    _this.title = title;
+    _this.imageUrl = imageUrl;
+    return _this;
+  }
+
+  _createClass(GifModel, [{
+    key: "save",
+    value: function save() {
+      var obj, objKeys, objValues, valuesCount, i, queryStr, res;
+      return regeneratorRuntime.async(function save$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              obj = GifModel.name;
+              obj = obj.replace('Model', 's').toLowerCase(); // console.log(obj);
+
+              objKeys = Object.keys(this);
+              objValues = Object.values(this);
+              valuesCount = [];
+
+              for (i = 1; i <= objKeys.length; i++) {
+                valuesCount.push("$".concat(i));
+              } // console.log(objKeys, objValues, valuesCount);
+
+
+              queryStr = "".concat((0, _query.saveQuery)(obj), " (").concat(objKeys, ") values (").concat(valuesCount, ") RETURNING *"); // console.log(queryStr);
+
+              if (!(objValues === undefined)) {
+                _context.next = 10;
+                break;
+              }
+
+              console.log('Values not supplied');
+              return _context.abrupt("return");
+
+            case 10:
+              _context.next = 12;
+              return regeneratorRuntime.awrap(_db["default"].query(queryStr, objValues).then(function (result) {
+                return result.rows;
+              })["catch"](function (err) {
+                return 'Error found here!', err.message;
+              }));
+
+            case 12:
+              res = _context.sent;
+              return _context.abrupt("return", res);
+
+            case 14:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, null, this);
+    }
+  }]);
+
+  return GifModel;
+}(_index["default"]);
+
+var _default = GifModel;
+exports["default"] = _default;

--- a/build/routes/gifRoutes.js
+++ b/build/routes/gifRoutes.js
@@ -1,0 +1,19 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _express = _interopRequireDefault(require("express"));
+
+var _gifController = _interopRequireDefault(require("../controllers/gifController"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+var router = _express["default"].Router(); // router.post('/', GifController.createGif);
+
+
+router["delete"]('/:gifId', _gifController["default"].deleteGif);
+var _default = router;
+exports["default"] = _default;

--- a/build/routes/index.js
+++ b/build/routes/index.js
@@ -9,6 +9,8 @@ var _employeeRoutes = _interopRequireDefault(require("./employeeRoutes"));
 
 var _articleRoutes = _interopRequireDefault(require("./articleRoutes"));
 
+var _gifRoutes = _interopRequireDefault(require("./gifRoutes"));
+
 var _testRoutes = _interopRequireDefault(require("./testRoutes"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
@@ -16,6 +18,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 var _default = function _default(app) {
   app.use('/api/v1/auth', _employeeRoutes["default"]);
   app.use('/api/v1/articles', _articleRoutes["default"]);
+  app.use('/api/v1/gifs', _gifRoutes["default"]);
   app.use('/api/v1/test', _testRoutes["default"]);
 };
 

--- a/build/test/test.spec.js
+++ b/build/test/test.spec.js
@@ -14,6 +14,8 @@ var _employeeController = _interopRequireDefault(require("../controllers/employe
 
 var _articleController = _interopRequireDefault(require("../controllers/articleController"));
 
+var _gifController = _interopRequireDefault(require("../controllers/gifController"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
@@ -32,6 +34,20 @@ describe('Test Endpoints', function () {
   });
   it('test method (GET) should exist', function () {
     _controllers["default"].test.should.exist;
+  });
+  it('test method (GET) should exist', function (done) {
+    _chai["default"].request(_main["default"]).get('/api/v1/test').end(function (err, res) {
+      res.should.have.status(200);
+      res.should.be.json;
+      res.body.should.be.a('object');
+      res.body.should.have.property('status');
+      res.body.status.should.be.a('string');
+      res.body.should.have.property('data');
+      res.body.data.should.be.a('object');
+      res.body.data.should.have.property('test');
+    });
+
+    done();
   });
 });
 describe('Employee Endpoints', function () {
@@ -529,6 +545,176 @@ describe('Article Endpoints', function () {
     _chai["default"].request(_main["default"]).post('/api/v1/articles/100000/comment').send({
       authorId: 1,
       comment: 'latest comment'
+    }).end(function (err, res) {
+      res.should.have.status(400);
+      res.should.be.json;
+      res.body.should.be.a('object');
+      res.body.should.have.property('status');
+      res.body.status.should.be.a('string');
+      res.body.should.have.property('error');
+      res.body.error.should.be.a('string');
+    });
+
+    done();
+  });
+}); // Test createGif Endpoints
+
+describe('GIF Endpoints', function () {
+  it('GifController should exist', function () {
+    _gifController["default"].should.exist;
+  }); // it('createGif method (POST) should exist', () => {
+  //   GifController.createGif.should.exist;
+  // });
+  // it('createGif method (POST) should create gif post with title & image(Url)', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 1,
+  //       title: `Test Edition${count}`,
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(201);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('data');
+  //       res.body.data.should.be.a('object');
+  //       res.body.data.should.have.property('gifId');
+  //       res.body.data.should.have.property('message');
+  //       res.body.data.should.have.property('createdOn');
+  //       res.body.data.should.have.property('title');
+  //       res.body.data.should.have.property('imageUrl');
+  //     });
+  //   done();
+  // });
+  // it('createGif method (POST) should return ERROR if any value is missing', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 1,
+  //       title: '',
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(400);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('error');
+  //       res.body.error.should.be.a('string');
+  //     });
+  //   done();
+  // });
+  // it('createGif method (POST) should return ERROR if author NOT FOUND', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 0,
+  //       title: `Test Edition${count + 1}`,
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(400);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('error');
+  //       res.body.error.should.be.a('string');
+  //     });
+  //   done();
+  // });
+  // it('createGif method (POST) should return ERROR if gif post already exists', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 1,
+  //       title: `Test Edition${count}`,
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(400);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('error');
+  //       res.body.error.should.be.a('string');
+  //     });
+  //   done();
+  // });
+  // Test deleteGif Endpoints
+
+  it('deleteGif method (DELETE) should exist', function () {
+    _gifController["default"].deleteGif.should.exist;
+  });
+  it('deleteGif method (DELETE) should delete an article', function (done) {
+    _chai["default"].request(_main["default"])["delete"]('/api/v1/gifs/1').send({
+      authorId: 1
+    }).end(function (err, res) {
+      res.should.have.status(200);
+      res.should.be.json;
+      res.body.should.be.a('object');
+      res.body.should.have.property('status');
+      res.body.status.should.be.a('string');
+      res.body.should.have.property('data');
+      res.body.data.should.be.a('object');
+      res.body.data.should.have.property('message');
+    });
+
+    done();
+  });
+  it('deleteGif method (DELETE) should return ERROR if gifId is not a number', function (done) {
+    _chai["default"].request(_main["default"])["delete"]('/api/v1/gifs/a').send({
+      authorId: 1
+    }).end(function (err, res) {
+      res.should.have.status(400);
+      res.should.be.json;
+      res.body.should.be.a('object');
+      res.body.should.have.property('status');
+      res.body.status.should.be.a('string');
+      res.body.should.have.property('error');
+      res.body.error.should.be.a('string');
+    });
+
+    done();
+  });
+  it('deleteGif method (DELETE) should return ERROR if authorId is not a number', function (done) {
+    _chai["default"].request(_main["default"])["delete"]('/api/v1/gifs/1').send({
+      authorId: 'a'
+    }).end(function (err, res) {
+      res.should.have.status(400);
+      res.should.be.json;
+      res.body.should.be.a('object');
+      res.body.should.have.property('status');
+      res.body.status.should.be.a('string');
+      res.body.should.have.property('error');
+      res.body.error.should.be.a('string');
+    });
+
+    done();
+  });
+  it('deleteGif method (DELETE) should return ERROR if any value is missing', function (done) {
+    _chai["default"].request(_main["default"])["delete"]('/api/v1/gifs/1').send({
+      authorId: ''
+    }).end(function (err, res) {
+      res.should.have.status(400);
+      res.should.be.json;
+      res.body.should.be.a('object');
+      res.body.should.have.property('status');
+      res.body.status.should.be.a('string');
+      res.body.should.have.property('error');
+      res.body.error.should.be.a('string');
+    });
+
+    done();
+  });
+  it('deleteGif method (DELETE) should return ERROR if GIF is NOT FOUND', function (done) {
+    _chai["default"].request(_main["default"])["delete"]('/api/v1/gifs/100000').send({
+      authorId: 1
     }).end(function (err, res) {
       res.should.have.status(400);
       res.should.be.json;

--- a/src/controllers/gifController.js
+++ b/src/controllers/gifController.js
@@ -1,0 +1,148 @@
+import GifModel from '../models/gifModel';
+import EmployeeModel from '../models/employeeModel';
+
+
+class GifController {
+// create GIFs
+
+// static async createGif(req, res) {
+//     const { title, imageUrl } = req.body;
+//     // const authorId = parseInt(req.body.authorId, 10);
+//     let authorId = req.body.authorId;
+
+//     const newGif = new GifModel(authorId, title, imageUrl);
+//     // console.log(newGif);
+
+// const missingValue = Object.keys(newGif)
+//                            .filter(item => ((newGif[item] === undefined) || (newGif[item] === '')));
+// // console.log(missingValue);
+// if (missingValue.length > 0) {
+//       return res.status(400).json({
+//         status: 'error',  
+//         error: `${missingValue} not supplied`,
+//     });
+// }
+ 
+//     const authorExist = await EmployeeModel.find(`userid=${newGif.authorId}`);
+//     if (authorExist) {
+//       if (authorExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with author' });
+//       if (authorExist.length < 1) return res.status(400).json({ status: 'error', error: 'Author not found' });
+//     }
+
+//     const gifExist = await GifModel.find(`title=${newGif.title}`);
+//     // console.log('gif exist', gifExist);
+//     if (gifExist) {
+//       if (gifExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with GIF' });
+//       if (gifExist.length > 0) return res.status(400).json({ status: 'error', error: 'GIF already exists' });
+//     }
+
+  
+//     const createdGif = await newGif.save();
+//     if (createdGif.indexOf('not') >= 0) {
+//       return res.status(400).json({ status: 'error', error: 'Some error found with new GIF' });
+//     }
+
+//     const data = {
+//         gifId: createdGif[0].gifId,
+//         message: 'GIF image successfully posted',
+//         createdOn: createdGif[0].createdon,
+//         title: createdGif[0].title,
+//         imageUrl: createdGif[0].imageurl,
+//     }
+    
+//     return res.status(201).json({
+//         status: 'success',
+//         data,
+//      });
+//   }
+     
+  
+  // Delete GIFs by ID
+
+  static async deleteGif(req, res) {
+    const { gifId } = req.params;
+    let authorId = req.body.authorId;
+
+    if (authorId === undefined) {
+          return res.status(400).json({
+            status: 'error',  
+            error: 'authorId not supplied',
+        });
+    }
+      authorId = parseInt(authorId, 10);
+
+    if (isNaN(gifId)) return res.status(400).json({ status: 'error', error: 'gifId must be a number'});
+    if (isNaN(authorId)) return res.status(400).json({ status: 'error', error: 'authorId must be a number'});
+
+    const gifExist = await GifModel.findByJoin('employees', `gifs.authorid=employees.userid`, `gifid=${gifId} AND authorid=${authorId}`);
+    if (gifExist) {
+      if (gifExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with GIF' });
+      if (gifExist.length < 1) return res.status(400).json({ status: 'error', error: 'GIF not found' });
+    }
+    // console.log('GIF exist', gifExist[0]);
+    const gifDeleted = await GifModel.delete(`gifid=${gifId}`);
+
+    return res.status(200).json({
+      status: 'success',
+      data: {
+        message: 'gif post successfully deleted'
+      }
+    });
+  }
+
+// Create comment on gif posts by ID
+
+// static async createComment(req, res) {
+//     const { authorId, comment } = req.body;
+//     const { articleId } = req.params;
+  
+//         const commentToBeCreated = new CommentModel(authorId, gifId, comment);
+//         // console.log(commentToBeCreated);
+        
+//         const missingValue = Object.keys(commentToBeCreated)
+//                                   .filter(item => ((commentToBeCreated[item] === undefined) || (commentToBeCreated[item] === '')));
+//         // console.log(missingValue);
+//         if (missingValue.length > 0) {
+//               return res.status(400).json({
+//                 status: 'error',  
+//                 error: `${missingValue} not supplied`,
+//             });
+//         }
+    
+//       if (isNaN(gifId)) return res.status(400).json({ status: 'error', error: 'gifId must be a number'});
+//       if (isNaN(authorId)) return res.status(400).json({ status: 'error', error: 'authorId must be a number'});
+  
+//       const gifExist = await GifModel.findByJoin('employees', `articles.authorid=employees.userid`, `gifarticleid=${gifarticleId} AND authorid=${authorId}`);
+//       if (gifExist) {
+//         if (gifExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found with gif post' });
+//         if (gifExist.length < 1) return res.status(400).json({ status: 'error', error: 'gif post not found' });
+//       }
+//       // console.log('GIF exist', gifExist[0]);
+
+//       const commentExist = await CommentModel.findByJoin('gifs', `comments.gifid=gifs.gifid`, `gifs.gifid=${gifId} AND comments.comment='${comment}'`);
+//       // console.log('comment exist', commentExist);
+
+//       if (commentExist) {
+//         if (commentExist.indexOf('not') >= 0) return res.status(400).json({ status: 'error', error: 'Some error found' });
+//         if (commentExist.length > 0) return res.status(400).json({ status: 'error', error: 'Same comment already given' });
+//       }
+
+//       const newComment = await commentToBeCreated.save();
+//       if (newComment.indexOf('not') >= 0) {
+//         return res.status(400).json({ error: 'Some error found with new comment' });
+//       }
+
+//       const data = {
+//         message: 'Comment successfully created',
+//         createdOn: newComment[0].createdon,
+//         gifTitle: gifExist[0].title,
+//         comment,
+//       }
+//       return res.status(201).json({
+//         data,
+//       });
+//   }
+
+}
+
+export default GifController;

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,13 +1,6 @@
 const TestController = {
     test: (req, res, next) => {
 
-
-        // if(err) {
-        //     return res.status(400).json({
-        //         status: 'error',
-        //         error: 'test setup has some error'
-        //     });
-        // }
         res.status(200).json({
             status: 'success',
             data: {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -1,6 +1,9 @@
 import { Client } from 'pg';
 import 'dotenv/config';
 
+
+const elephantSql = 'postgres://aikuwuqy:VwJSaP-pOdEc--_ZNpS-g2zHekiTgLJK@raja.db.elephantsql.com:5432/aikuwuqy';
+
 const dbUrl = {
   host: process.env.HOST,
   user: process.env.USER,
@@ -22,8 +25,9 @@ console.log('NODE_ENV', process.env.NODE_ENV);
 
 let db;
 
-if (process.env.NODE_ENV === 'test') {
-  db = new Client(dbUrlTest);
+if (process.env.NODE_ENV !== 'test') {
+  // db = new Client(dbUrlTest);
+  db = new Client(elephantSql);
   console.log('Environment => Testing');
 } else {
   db = new Client(dbUrl);

--- a/src/models/gifModel.js
+++ b/src/models/gifModel.js
@@ -1,0 +1,43 @@
+import BaseModel from './index';
+import db from '../db';
+import { saveQuery } from '../db/query';
+
+class GifModel extends BaseModel {
+  constructor(authorId, title, imageUrl) {
+    super();
+    this.authorId = authorId;
+    this.title = title;
+    this.imageUrl = imageUrl;
+  }
+
+
+  async save() {
+    let obj = GifModel.name;
+    obj = obj.replace('Model', 's').toLowerCase();
+    // console.log(obj);
+    const objKeys = Object.keys(this);
+    const objValues = Object.values(this);
+    const valuesCount = [];
+    for (let i = 1; i <= objKeys.length; i++) {
+      valuesCount.push(`$${i}`);
+    }
+    // console.log(objKeys, objValues, valuesCount);
+
+    const queryStr = `${saveQuery(obj)} (${objKeys}) values (${valuesCount}) RETURNING *`;
+    // console.log(queryStr);
+    if (objValues === undefined) {
+      console.log('Values not supplied');
+      return;
+    }
+    // console.log(queryStr, objValues);
+
+    const res = await db.query(queryStr, objValues)
+      .then(result => result.rows)
+      .catch(err => ('Error found here!', err.message));
+    // console.log(res[0]);
+    return res;
+  }
+}
+
+
+export default GifModel;

--- a/src/routes/gifRoutes.js
+++ b/src/routes/gifRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import GifController from '../controllers/gifController';
+
+const router = express.Router();
+
+
+// router.post('/', GifController.createGif);
+
+router.delete('/:gifId', GifController.deleteGif);
+
+ 
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,12 @@
 import auth from './employeeRoutes';
 import articles from './articleRoutes';
+import gifs from './gifRoutes';
 import test from './testRoutes';
 
 
 export default (app) => {
   app.use('/api/v1/auth', auth);
   app.use('/api/v1/articles', articles);
+  app.use('/api/v1/gifs', gifs);
   app.use('/api/v1/test', test);
 };

--- a/src/test/test.spec.js
+++ b/src/test/test.spec.js
@@ -4,6 +4,7 @@ import server from '../main';
 import TestController from '../controllers';
 import EmployeeController from '../controllers/employeeController'; 
 import ArticleController from '../controllers/articleController';
+import GifController from '../controllers/gifController';
 
 chai.use(chaiHttp);
 should();
@@ -19,6 +20,22 @@ describe('Test Endpoints', () => {
 
   it('test method (GET) should exist', () => {
     TestController.test.should.exist;
+  });
+
+  it('test method (GET) should exist', (done) => {
+    chai.request(server)
+      .get('/api/v1/test')
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('data');
+        res.body.data.should.be.a('object');
+        res.body.data.should.have.property('test');
+      });
+    done();
   });
 });
 
@@ -621,4 +638,199 @@ describe('Article Endpoints', () => {
     done();
   });
   
+});
+
+
+    // Test createGif Endpoints
+
+describe('GIF Endpoints', () => {
+  it('GifController should exist', () => {
+    GifController.should.exist;
+  });
+
+  // it('createGif method (POST) should exist', () => {
+  //   GifController.createGif.should.exist;
+  // });
+
+  // it('createGif method (POST) should create gif post with title & image(Url)', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 1,
+  //       title: `Test Edition${count}`,
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(201);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('data');
+  //       res.body.data.should.be.a('object');
+  //       res.body.data.should.have.property('gifId');
+  //       res.body.data.should.have.property('message');
+  //       res.body.data.should.have.property('createdOn');
+  //       res.body.data.should.have.property('title');
+  //       res.body.data.should.have.property('imageUrl');
+  //     });
+  //   done();
+  // });
+
+  // it('createGif method (POST) should return ERROR if any value is missing', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 1,
+  //       title: '',
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(400);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('error');
+  //       res.body.error.should.be.a('string');
+  //     });
+  //   done();
+  // });
+
+  // it('createGif method (POST) should return ERROR if author NOT FOUND', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 0,
+  //       title: `Test Edition${count + 1}`,
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(400);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('error');
+  //       res.body.error.should.be.a('string');
+  //     });
+  //   done();
+  // });
+
+  // it('createGif method (POST) should return ERROR if gif post already exists', (done) => {
+  //   chai.request(server)
+  //     .post('/api/v1/gifs')
+  //     .send({
+  //       authorId: 1,
+  //       title: `Test Edition${count}`,
+  //       image: '',
+  //     })
+  //     .end((err, res) => {
+  //       res.should.have.status(400);
+  //       res.should.be.json;
+  //       res.body.should.be.a('object');
+  //       res.body.should.have.property('status');
+  //       res.body.status.should.be.a('string');
+  //       res.body.should.have.property('error');
+  //       res.body.error.should.be.a('string');
+  //     });
+  //   done();
+  // });
+
+   // Test deleteGif Endpoints
+   it('deleteGif method (DELETE) should exist', () => {
+    GifController.deleteGif.should.exist;
+  });
+
+  it('deleteGif method (DELETE) should delete an article', (done) => {
+    chai.request(server)
+      .delete('/api/v1/gifs/1')
+      .send({
+        authorId: 1,
+      })
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('data');
+        res.body.data.should.be.a('object');
+        res.body.data.should.have.property('message');
+      });
+    done();
+  });
+
+  it('deleteGif method (DELETE) should return ERROR if gifId is not a number', (done) => {
+    chai.request(server)
+      .delete('/api/v1/gifs/a')
+      .send({
+        authorId: 1,
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
+  it('deleteGif method (DELETE) should return ERROR if authorId is not a number', (done) => {
+    chai.request(server)
+      .delete('/api/v1/gifs/1')
+      .send({
+        authorId: 'a',
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
+  it('deleteGif method (DELETE) should return ERROR if any value is missing', (done) => {
+    chai.request(server)
+      .delete('/api/v1/gifs/1')
+      .send({
+        authorId: '',
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+  
+  it('deleteGif method (DELETE) should return ERROR if GIF is NOT FOUND', (done) => {
+    chai.request(server)
+      .delete('/api/v1/gifs/100000')
+      .send({
+        authorId: 1,
+      })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.be.a('string');
+        res.body.should.have.property('error');
+        res.body.error.should.be.a('string');
+      });
+    done();
+  });
+
 });


### PR DESCRIPTION
What does this PR do?
create an endpoint for users to be able to delete their gif posts

Description of Task to be completed?
create endpoint where registered users can their gif posts by sending the post details by a DELETE request to '/api/v1/gifs/:gifId'

How should this be manually tested?
Clone repo, run npm install, test with Postman

Any background context you want to provide? NA
What are the relevant pivotal tracker stories?
Github Project Board : #29067759

Screenshots (if appropriate): NA

Questions: NA