### PR TITLE
#29605433:create the get specific gif post endpoint

### DIFF
--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -203,17 +203,17 @@ class ArticleController {
     const { authorId } = req.body;
     const { articleId } = req.params;
 
-    // if (authorId === undefined) {
-    //   return res.status(400).json({
-    //     status: 'error',  
-    //     error: 'authorId not supplied',
-    //   });
-    // }
+    if (authorId === undefined) {
+      return res.status(400).json({
+        status: 'error',  
+        error: 'authorId not supplied',
+      });
+    }
     
 
-    console.log(articleId, req.params, req.query);
+    // console.log(articleId, req.params, req.query);
     const regExp = 'category';
-    console.log(regExp.includes(articleId));
+    // console.log(regExp.includes(articleId));
     // if (regExp.includes(articleId)) {
     //   return res.status(400).json({
     //       status: 'error',
@@ -223,7 +223,7 @@ class ArticleController {
   if (articleId === 'category') {
       
       const { searchQuery } = req.query;
-      console.log('search query', searchQuery);
+      // console.log('search query', searchQuery);
 
       if (searchQuery === undefined) {
         return res.status(400).json({
@@ -232,7 +232,7 @@ class ArticleController {
         });
       }
       const searchResult = await ArticleModel.search(`article=${searchQuery}`);
-      console.log('search result', searchResult);
+      // console.log('search result', searchResult);
 
       return res.status(200).json({
         status: 'success',

--- a/src/controllers/gifController.js
+++ b/src/controllers/gifController.js
@@ -162,12 +162,12 @@ static async createComment(req, res) {
     const { authorId } = req.body;
     const { gifId } = req.params;
 
-    // if (authorId === undefined) {
-    //   return res.status(400).json({
-    //     status: 'error',  
-    //     error: 'authorId not supplied',
-    //   });
-    // }
+    if (authorId === undefined) {
+      return res.status(400).json({
+        status: 'error',  
+        error: 'authorId not supplied',
+      });
+    }
     if (isNaN(gifId)) {
       return res.status(400).json({ status: 'error', message: 'Invalid gif post ID' });
     }


### PR DESCRIPTION
What does this PR do?
create an endpoint to view a specific gif post by ID

Description of Task to be completed?
create endpoint where registered users can view a specific article by sending the gif post ID with a GET request to '/api/v1/gifs/<gifId>'

How should this be manually tested?
Clone repo, run npm install, test with Postman

Any background context you want to provide? NA
What are the relevant pivotal tracker stories?
Github Project Board : #29605433

Screenshots (if appropriate): NA

Questions: NA