### PR TITLE
feature(endpoint):create view by category endpoint

### DIFF
--- a/src/controllers/feedController.js
+++ b/src/controllers/feedController.js
@@ -5,7 +5,14 @@ class FeedController {
     // get feed of articles & gif posts
 
     static async getFeed(req, res) {
-
+        const { authorId } = req.body;
+        
+        if (authorId === undefined) {
+            return res.status(400).json({
+              status: 'error',  
+              error: 'authorId not supplied',
+            });
+          }
         const gifarticles = await db.query('SELECT * FROM articles UNION SELECT  * FROM gifs ORDER BY lastupdated DESC')
                                     .then(result => result.rows)
                                     .catch(err => {


### PR DESCRIPTION
What does this PR do?
create endpoint to view articles by category(tag)

Description of Task to be completed?
create endpoint where registered users can view all articles that belong to a particular category(tag) with a GET request to '/api/v1/articles/category?searchQuery='query'

How should this be manually tested?
Clone repo, run npm install, test with Postman

Any background context you want to provide? NA
What are the relevant pivotal tracker stories?
Github Project Board : #29068294

Screenshots (if appropriate): NA

Questions: NA