### PR TITLE
#29068459:create endpoint to delete flagged entity

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,33 @@
+gitplugins:
+  duplication:
+    enabled: true
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 7
+  file-lines:
+    config:
+      threshold: 300
+  method-complexity:
+    config:
+      threshold: 7
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 35
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 7
+exclude_patterns:
+  - "node_modules/"
+  - "src/test/"
+  - "dist/"
+  - "coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,21 @@ cache:
 services :
   - postgresql
 
+env:
+  global:
+    - CC_TEST_REPORTER_ID=6296573675c38ff0324b0c3c964ea2e5029532e67de1c2d6f025ef0b49e53d8f
+    # - NODE_ENV=test
+
 before_script:
-  # - psql -c 'create database test_teamwork;' -U postgres
-  # - psql -c `create user postgres with password 'animalworld';` -U postgres
-  # - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  # - chmod +x ./cc-test-reporter
-  # - ./cc-test-reporter before-build
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 
 script:
  - npm test
+
+ after_success:
  - npm run coverage
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ An internal social network for employees of an organization
 
 [![Build Status](https://travis-ci.com/thevetdoctor/teamwork.svg?token=1W6dsC3j7dgMFzDtHnEz&branch=develop)](https://travis-ci.com/thevetdoctor/teamwork)
 [![Coverage Status](https://coveralls.io/repos/github/thevetdoctor/teamwork/badge.svg?branch=develop)](https://coveralls.io/github/thevetdoctor/teamwork?branch=develop)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/e18ba1eea3f7b9af77dc/test_coverage)](https://codeclimate.com/github/thevetdoctor/teamwork/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/e18ba1eea3f7b9af77dc/maintainability)](https://codeclimate.com/github/thevetdoctor/teamwork/maintainability)

--- a/bash.exe.stackdump
+++ b/bash.exe.stackdump
@@ -1,0 +1,4 @@
+Stack trace:
+Frame     Function  Args
+0022AEE8  610799F8 (00000000, 00000000, 00000000, 00000000)
+End of stack trace

--- a/src/controllers/feedController.js
+++ b/src/controllers/feedController.js
@@ -91,7 +91,7 @@ class FeedController {
             const argumentsObj = { authorId, id, type };
             const missingValue = Object.keys(argumentsObj)
             .filter(item => ((argumentsObj[item] === undefined) || (argumentsObj[item] === '')));
-            // console.log(missingValue);
+
             if (missingValue.length > 0) {
             return res.status(400).json({
             status: 'error',  
@@ -99,7 +99,6 @@ class FeedController {
             });
             }
 
-            // console.log('req body', req.body);
 
             const entityToDelete = await db.query(`SELECT * FROM ${type}s WHERE ${type}id=${id}`)
                                             .then(result => result.rows)
@@ -121,7 +120,7 @@ class FeedController {
                     error: `${type} should be FLAGGED before DELETION`
                 }) 
             }
-            console.log('entity to delete', entityToDelete);
+            // console.log('entity to delete', entityToDelete);
           const deletedEntity = await db.query(`DELETE FROM ${type}s WHERE ${type}id=${id} RETURNING *`)
                                         .then(result => result.rows)
                                         .catch(err => {

--- a/src/main.js
+++ b/src/main.js
@@ -43,7 +43,7 @@ app.use((error, req, res, next) => {
 
 app.get('/api/v1', (req, res, next) => {
     
-    res.send('<div style=\'text-align: center;\'><h1>Welcome to Teamwork</h1><h3>... where teams actually WORK!</h3><img src=\'https://res.cloudinary.com/thevetdoctor/image/upload/v1554313024/oba.jpg\'/></div>');
+    res.send('<div style=\'text-align: center;\'><h1>Welcome to Teamwork</h1><h3>... where teams actually WORK!</h3><img src=\'https://res.cloudinary.com/thevetdoctor/image/upload/v1574600900/teamwork/Penguins.jpg\'/></div>');
 });
  
 app.get('/', (req, res, next) => {


### PR DESCRIPTION
What does this PR do?
create an endpoint for admin to be able to delete entity flagged as inappropriate

Description of Task to be completed?
create endpoint where admin to be able to delete an article, gif post or comment flagged as inappropriate by sending a DELETE request to '/api/v1/feed'

How should this be manually tested?
Clone repo, run npm install, test with Postman

Any background context you want to provide? NA
What are the relevant pivotal tracker stories?
Github Project Board : #-card-29068459

Screenshots (if appropriate):NA

Questions: NA